### PR TITLE
Enable TorchTune and Meta Checkpointers to use dcp behind a flag

### DIFF
--- a/recipes/configs/llama3_1/8B_full.yaml
+++ b/recipes/configs/llama3_1/8B_full.yaml
@@ -18,13 +18,12 @@
 # best to use 8B_full_single_device.yaml for those cases
 
 
-
 output_dir: /tmp/torchtune/llama3_1_8B/full # /tmp may be deleted by your system. Change it to your preference.
 
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.llama3.llama3_tokenizer
-  path: /home/ankitageorge/.cache/huggingface/hub/models--meta-llama--Llama-3.1-8B-Instruct/blobs/82e9d31979e92ab929cd544440f129d9ecd797b69e327f80f17e1c50d5551b55
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
   max_seq_len: null
 
 # Dataset
@@ -37,15 +36,19 @@ shuffle: True
 # Model Arguments
 model:
   _component_: torchtune.models.llama3_1.llama3_1_8b
-# temp changes for testing locally
+
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
-  checkpoint_dir: hf://meta-llama/Llama-3.1-8B-Instruct/
-  checkpoint_files: []
+  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
+  checkpoint_files: [
+    model-00001-of-00004.safetensors,
+    model-00002-of-00004.safetensors,
+    model-00003-of-00004.safetensors,
+    model-00004-of-00004.safetensors
+  ]
   recipe_checkpoint: null
-  output_dir: hf://ankitageorge/Llama-testing/
+  output_dir: ${output_dir}
   model_type: LLAMA3
-  enable_dcp: True
 resume_from_checkpoint: False
 
 # Fine-tuning arguments

--- a/recipes/configs/llama3_1/8B_full.yaml
+++ b/recipes/configs/llama3_1/8B_full.yaml
@@ -18,12 +18,13 @@
 # best to use 8B_full_single_device.yaml for those cases
 
 
+
 output_dir: /tmp/torchtune/llama3_1_8B/full # /tmp may be deleted by your system. Change it to your preference.
 
 # Tokenizer
 tokenizer:
   _component_: torchtune.models.llama3.llama3_tokenizer
-  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  path: /home/ankitageorge/.cache/huggingface/hub/models--meta-llama--Llama-3.1-8B-Instruct/blobs/82e9d31979e92ab929cd544440f129d9ecd797b69e327f80f17e1c50d5551b55
   max_seq_len: null
 
 # Dataset
@@ -36,19 +37,15 @@ shuffle: True
 # Model Arguments
 model:
   _component_: torchtune.models.llama3_1.llama3_1_8b
-
+# temp changes for testing locally
 checkpointer:
   _component_: torchtune.training.FullModelHFCheckpointer
-  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
-  checkpoint_files: [
-    model-00001-of-00004.safetensors,
-    model-00002-of-00004.safetensors,
-    model-00003-of-00004.safetensors,
-    model-00004-of-00004.safetensors
-  ]
+  checkpoint_dir: hf://meta-llama/Llama-3.1-8B-Instruct/
+  checkpoint_files: []
   recipe_checkpoint: null
-  output_dir: ${output_dir}
+  output_dir: hf://ankitageorge/Llama-testing/
   model_type: LLAMA3
+  enable_dcp: True
 resume_from_checkpoint: False
 
 # Fine-tuning arguments

--- a/tests/torchtune/training/checkpointing/test_checkpointer.py
+++ b/tests/torchtune/training/checkpointing/test_checkpointer.py
@@ -6,6 +6,9 @@
 
 import json
 
+import os
+import shutil
+
 from pathlib import Path
 from typing import Tuple
 
@@ -13,6 +16,7 @@ import pytest
 
 import torch
 from torch import randn
+from torchtune import training
 
 from torchtune.models import gemma, llama2, mistral
 from torchtune.modules.peft import (
@@ -21,7 +25,11 @@ from torchtune.modules.peft import (
     validate_missing_and_unexpected_for_lora,
 )
 
-from torchtune.training.checkpointing import FullModelHFCheckpointer
+from torchtune.training.checkpointing import (
+    FullModelHFCheckpointer,
+    FullModelMetaCheckpointer,
+    FullModelTorchTuneCheckpointer,
+)
 
 from torchtune.training.checkpointing._utils import (
     ADAPTER_CONFIG,
@@ -818,3 +826,157 @@ class TestHFGemmaFullModelCheckpointer:
         output_state_dict = safe_torch_load(output_file)
 
         assert len(output_state_dict.keys()) == len(orig_state_dict.keys())
+
+
+class TestFullModelTorchTuneCheckpointer:
+    @pytest.fixture
+    def weight_dtype(self):
+        return torch.float16
+
+    @pytest.fixture
+    def state_dict(self, weight_dtype):
+        """
+        State dict
+        """
+        state_dict = {
+            "model.embed_tokens.weight": randn(_VOCAB_SIZE, _DIM, dtype=weight_dtype),
+            "model.layers.0.input_layernorm.weight": randn(_DIM, dtype=weight_dtype),
+            "model.layers.0.self_attn.q_proj.weight": randn(
+                _DIM, _DIM, dtype=weight_dtype
+            ),
+            "model.layers.0.self_attn.k_proj.weight": randn(
+                _DIM, _DIM, dtype=weight_dtype
+            ),
+            "model.layers.0.self_attn.v_proj.weight": randn(
+                _DIM, _DIM, dtype=weight_dtype
+            ),
+            "model.layers.0.self_attn.o_proj.weight": randn(
+                _DIM, _DIM, dtype=weight_dtype
+            ),
+            "model.layers.0.post_attention_layernorm.weight": randn(
+                _DIM, dtype=weight_dtype
+            ),
+            "model.layers.0.self_attn.rotary_emb.inv_freq": randn(
+                _DIM, dtype=weight_dtype
+            ),
+            "model.layers.0.mlp.gate_proj.weight": randn(
+                _HIDDEN_DIM, _DIM, dtype=weight_dtype
+            ),
+            "model.layers.0.mlp.down_proj.weight": randn(
+                _DIM, _HIDDEN_DIM, dtype=weight_dtype
+            ),
+            "model.layers.0.mlp.up_proj.weight": randn(
+                _HIDDEN_DIM, _DIM, dtype=weight_dtype
+            ),
+            "model.norm.weight": randn(_DIM, dtype=weight_dtype),
+            "lm_head.weight": randn(_VOCAB_SIZE, _DIM, dtype=weight_dtype),
+        }
+
+        return {training.MODEL_KEY: state_dict}
+
+    @pytest.fixture
+    def checkpointer(self, tmp_path) -> FullModelTorchTuneCheckpointer:
+        checkpoint_dir = Path.joinpath(tmp_path, "checkpoint_dir")
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+        return FullModelTorchTuneCheckpointer(
+            checkpoint_dir=str(checkpoint_dir),
+            output_dir=tmp_path,
+            checkpoint_files=[],
+            model_type="LLAMA2",
+            enable_dcp=True,
+        )
+
+    def test_save_load_checkpoint_with_dcp(self, checkpointer, state_dict):
+        """
+        Test ``load_checkpoint`` method within the FullModelTorchTuneCheckpointer
+        with dcp enabled.
+
+        We test:
+        * ``load_checkpoint`` loads the right sets of keys
+        * Internal state of the checkpointer is correctly updated.
+        """
+
+        checkpointer.save_checkpoint(state_dict=state_dict, epoch=1)
+
+        checkpoint_path = Path.joinpath(
+            checkpointer._output_dir,
+            "epoch_1/__0_0.distcp",
+        )
+
+        assert os.path.exists(checkpoint_path)
+        shutil.copy(checkpoint_path, checkpointer._checkpoint_dir)
+        shutil.copy(checkpoint_path.parent / ".metadata", checkpointer._checkpoint_dir)
+
+        loaded_state_dict = checkpointer.load_checkpoint()
+
+        for key in state_dict[training.MODEL_KEY].keys():
+            saved = state_dict[training.MODEL_KEY][key]
+            loaded = loaded_state_dict[training.MODEL_KEY][key]
+            assert torch.equal(
+                saved,
+                loaded,
+            )
+
+
+class TestFullModelMetaCheckpointer:
+    @pytest.fixture
+    def weight_dtype(self):
+        return torch.float16
+
+    @pytest.fixture
+    def state_dict(self, weight_dtype):
+        """
+        State dict
+        """
+
+        state_dict = {
+            "tok_embeddings.weight": randn(_VOCAB_SIZE, _DIM, dtype=weight_dtype),
+            "output.weight": randn(_DIM, _NUM_HEADS * _HEAD_DIM, dtype=weight_dtype),
+        }
+
+        return {training.MODEL_KEY: state_dict}
+
+    @pytest.fixture
+    def checkpointer(self, tmp_path) -> FullModelMetaCheckpointer:
+        checkpoint_dir = Path.joinpath(tmp_path, "checkpoint_dir")
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+        return FullModelMetaCheckpointer(
+            checkpoint_dir=str(checkpoint_dir),
+            output_dir=tmp_path,
+            checkpoint_files=[],
+            model_type="LLAMA2",
+            enable_dcp=True,
+        )
+
+    def test_save_load_checkpoint_with_dcp(self, checkpointer, state_dict):
+        """
+        Test ``load_checkpoint`` method within the FullModelTorchTuneCheckpointer
+        with dcp enabled.
+
+        We test:
+        * ``load_checkpoint`` loads the right sets of keys
+        * Internal state of the checkpointer is correctly updated.
+        """
+
+        checkpointer.save_checkpoint(state_dict=state_dict, epoch=1)
+
+        checkpoint_path = Path.joinpath(
+            checkpointer._output_dir,
+            "__0_0.distcp",
+        )
+
+        assert os.path.exists(checkpoint_path)
+        shutil.copy(checkpoint_path, checkpointer._checkpoint_dir)
+        shutil.copy(checkpoint_path.parent / ".metadata", checkpointer._checkpoint_dir)
+
+        loaded_state_dict = checkpointer.load_checkpoint()
+
+        for key in state_dict[training.MODEL_KEY].keys():
+            saved = state_dict[training.MODEL_KEY][key]
+            loaded = loaded_state_dict[training.MODEL_KEY][key]
+            assert torch.equal(
+                saved,
+                loaded,
+            )

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -23,6 +23,7 @@ from torch.distributed.checkpoint import (
     load,
     save,
 )
+from torch.distributed.checkpoint.state_dict_loader import _load_state_dict_from_keys
 
 from torchtune import training
 from torchtune.models import convert_weights
@@ -156,11 +157,14 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         recipe_checkpoint: Optional[str] = None,
         resume_from_checkpoint: bool = False,
         should_load_recipe_state: bool = False,
+        enable_dcp: bool = False,
     ) -> None:
 
         # Fail fast if ``checkpoint_files`` is invalid
         # TODO: support loading more than one file
-        if len(checkpoint_files) != 1:
+        if len(checkpoint_files) != 1 and (
+            len(checkpoint_files) == 0 and not enable_dcp
+        ):
             raise ValueError(
                 "Currently we only support reading from a single checkpoint file. "
                 f"Got {len(checkpoint_files)} files instead."
@@ -207,7 +211,10 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         )
 
         # we currently accept only a single file
-        self._checkpoint_path = self._checkpoint_paths[0]
+        if len(self._checkpoint_paths) == 0:
+            self._checkpoint_path = self._checkpoint_dir / "__0_0.distcp"
+        else:
+            self._checkpoint_path = self._checkpoint_paths[0]
 
         if self._should_load_recipe_state:
             logger.info(
@@ -216,6 +223,8 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
                 f"\n\trecipe_checkpoint: {self._recipe_checkpoint}"
                 f"\n\tadapter_checkpoint: {self._adapter_checkpoint}"
             )
+
+        self._enable_dcp = enable_dcp
 
     def load_checkpoint(self, weights_only: bool = True) -> Dict[str, Any]:
         """
@@ -241,9 +250,19 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
             Dict[str, Any]: state_dict from the input checkpoint
         """
         state_dict: Dict[str:Any] = {}
-        state_dict[training.MODEL_KEY] = safe_torch_load(
-            self._checkpoint_path, weights_only=weights_only
-        )
+        if (
+            self._enable_dcp
+            and weights_only
+            and self._checkpoint_path.parent / ".metadata"
+            in self._checkpoint_path.parent.iterdir()
+        ):
+            state_dict[training.MODEL_KEY] = _load_state_dict_from_keys(
+                checkpoint_id=self._checkpoint_path.parent
+            )
+        else:
+            state_dict[training.MODEL_KEY] = safe_torch_load(
+                self._checkpoint_path, weights_only=weights_only
+            )
 
         if self._adapter_checkpoint:
             adapter_state_dict = safe_torch_load(self._adapter_checkpoint)
@@ -294,19 +313,26 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
 
         # Output file is always a .bin file with the epoch number in the name
         if not adapter_only:
-            shard_name = SHARD_FNAME.format(
-                cpt_idx="1".zfill(5), num_shards="1".zfill(5)
-            )
-            output_path = Path.joinpath(
-                self._output_dir, f"epoch_{epoch}", shard_name
-            ).with_suffix(".bin")
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            torch.save(state_dict[training.MODEL_KEY], output_path)
-            logger.info(
-                "Model checkpoint of size "
-                f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
-                f"saved to {output_path}"
-            )
+            if self._enable_dcp:
+                save(
+                    state_dict=state_dict[training.MODEL_KEY],
+                    checkpoint_id=Path.joinpath(self._output_dir, f"epoch_{epoch}"),
+                )
+            else:
+                shard_name = SHARD_FNAME.format(
+                    cpt_idx="1".zfill(5), num_shards="1".zfill(5)
+                )
+                output_path = Path.joinpath(
+                    self._output_dir, f"epoch_{epoch}", shard_name
+                ).with_suffix(".bin")
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                torch.save(state_dict[training.MODEL_KEY], output_path)
+
+                logger.info(
+                    "Model checkpoint of size "
+                    f"{os.path.getsize(output_path) / 1024**3:.2f} GiB "
+                    f"saved to {output_path}"
+                )
 
         if training.ADAPTER_KEY in state_dict:
             output_path = Path.joinpath(
@@ -966,11 +992,14 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
         recipe_checkpoint: Optional[str] = None,
         resume_from_checkpoint: bool = False,
         should_load_recipe_state: bool = False,
+        enable_dcp: bool = False,
     ) -> None:
 
         # Fail fast if ``checkpoint_files`` is invalid
         # TODO: support loading more than one file
-        if len(checkpoint_files) != 1:
+        if len(checkpoint_files) != 1 and (
+            len(checkpoint_files) == 0 and not enable_dcp
+        ):
             raise ValueError(
                 "Currently we only support reading from a single checkpoint file. "
                 f"Got {len(checkpoint_files)} files instead."
@@ -1014,8 +1043,10 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
             has_adapter_checkpoint=self._adapter_checkpoint is not None,
         )
 
-        # we currently accept only a single file
-        self._checkpoint_path = self._checkpoint_paths[0]
+        if len(self._checkpoint_paths) == 0:
+            self._checkpoint_path = self._checkpoint_dir / "__0_0.distcp"
+        else:
+            self._checkpoint_path = self._checkpoint_paths[0]
 
         if self._should_load_recipe_state:
             logger.info(
@@ -1025,12 +1056,23 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
                 f"\n\tadapter_checkpoint: {self._adapter_checkpoint}"
             )
 
+        self._enable_dcp = enable_dcp
+
     def load_checkpoint(self) -> Dict[str, Any]:
         """
         Load Meta checkpoint from file. Currently only loading from a single file is supported.
         """
         state_dict: Dict[str:Any] = {}
-        model_state_dict = safe_torch_load(self._checkpoint_path)
+        if (
+            self._enable_dcp
+            and self._checkpoint_path.parent / ".metadata"
+            in self._checkpoint_path.parent.iterdir()
+        ):
+            model_state_dict = _load_state_dict_from_keys(
+                checkpoint_id=self._checkpoint_path.parent
+            )
+        else:
+            model_state_dict = safe_torch_load(self._checkpoint_path)
         if self._model_type == ModelType.LLAMA3_VISION:
             from torchtune.models.llama3_2_vision._convert_weights import (
                 llama3_vision_meta_to_tune,
@@ -1118,12 +1160,18 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
             ).with_suffix(".bin")
             checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
 
-            torch.save(state_dict[training.MODEL_KEY], checkpoint_file)
-            logger.info(
-                "Model checkpoint of size "
-                f"{os.path.getsize(checkpoint_file) / 1024**3:.2f} GiB "
-                f"saved to {checkpoint_file}"
-            )
+            if self._enable_dcp:
+                save(
+                    state_dict=state_dict[training.MODEL_KEY],
+                    checkpoint_id=self._output_dir,
+                )
+            else:
+                torch.save(state_dict[training.MODEL_KEY], checkpoint_file)
+                logger.info(
+                    "Model checkpoint of size "
+                    f"{os.path.getsize(checkpoint_file) / 1024**3:.2f} GiB "
+                    f"saved to {checkpoint_file}"
+                )
 
         if training.ADAPTER_KEY in state_dict:
             output_path = Path.joinpath(

--- a/torchtune/training/checkpointing/_checkpointer.py
+++ b/torchtune/training/checkpointing/_checkpointer.py
@@ -143,6 +143,7 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
         should_load_recipe_state (bool): If True, the checkpointer will load the additional checkpoint files corresponding to
             the recipe state from a previous run. Default is False
 
+
     Raises:
         ValueError: If more than one checkpoint file is provided
     """
@@ -166,7 +167,8 @@ class FullModelTorchTuneCheckpointer(_CheckpointerInterface):
             len(checkpoint_files) == 0 and not enable_dcp
         ):
             raise ValueError(
-                "Currently we only support reading from a single checkpoint file. "
+                "Currently we only support reading from a single checkpoint file, "
+                "or none if DCP is enabled."
                 f"Got {len(checkpoint_files)} files instead."
             )
 
@@ -977,6 +979,7 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
                 should_load_recipe_state instead.
         should_load_recipe_state (bool): If True, the checkpointer will load the additional checkpoint files corresponding to
                 the recipe state from a previous run. Default is False
+        enable_dcp (bool): If True, use DCP to load/save the checkpoint. Default is False.
 
     Raises:
         ValueError: If ``checkpoint_files`` is not a list of length 1
@@ -1001,7 +1004,8 @@ class FullModelMetaCheckpointer(_CheckpointerInterface):
             len(checkpoint_files) == 0 and not enable_dcp
         ):
             raise ValueError(
-                "Currently we only support reading from a single checkpoint file. "
+                "Currently we only support reading from a single checkpoint file, "
+                "or none if DCP is enabled."
                 f"Got {len(checkpoint_files)} files instead."
             )
 

--- a/torchtune/training/checkpointing/_utils.py
+++ b/torchtune/training/checkpointing/_utils.py
@@ -41,6 +41,7 @@ RECIPE_STATE_DIRNAME = "recipe_state"
 # Needed when setting up output dir in checkpointing
 REPO_ID_FNAME = "original_repo_id"
 SUFFIXES_TO_NOT_COPY = [
+    ".distcp",
     ".pt",
     ".pth",
     ".bin",


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ X] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
* Enable TorchTune and Meta checkpointers to take advantage of dcp saving and loading of checkpoints if enable_dcp is enabled.

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ x] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ x] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ x] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ x] run unit tests via `pytest tests`
- [ x] run recipe tests via `pytest tests -m integration_test`
- [ x] manually run any new or modified recipes with sufficient proof of correctness
- [ x] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ x] I have added an example to docs or docstrings
